### PR TITLE
EsperSDK - Usage section

### DIFF
--- a/docs/home/pythonsdk.md
+++ b/docs/home/pythonsdk.md
@@ -68,7 +68,7 @@ Next, you need to configure your client to talk to APIs. For this you will need 
 <pre>
 <code>
 configuration = esperclient.Configuration()
-configuration.host = ' https://{{ esper_tenant_name }}-api.esper.cloud/api'
+configuration.host = 'https://{{ esper_tenant_name }}-api.esper.cloud/api'
 configuration.api_key['Authorization'] = 'LpDriKp7MWJiRGcwc8xzREeUj8OEFa'
 configuration.api_key_prefix['Authorization'] = 'Bearer'
 </code>


### PR DESCRIPTION
Removed extra space before link for following line - 
configuration.host = 'https://{{ esper_tenant_name }}-api.esper.cloud/api'