### PR TITLE
Docs page-SEO issues (SHN-9128)

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -7,6 +7,17 @@ module.exports = {
     ['@dovyp/vuepress-plugin-clipboard-copy', true],
     ['@vuepress/back-to-top', true],
     ['@vuepress/plugin-medium-zoom', true],
+    [
+      'sitemap',
+      {
+          hostname: 'https://docs.esper.io',
+      },
+    ],
+    [ 'robots', {
+      host: 'https://docs.esper.io',
+      allowAll: true,    
+    } 
+    ],
     // [
     //   ('@vuepress/google-analytics',
     //   {

--- a/docs/home/console/index.md
+++ b/docs/home/console/index.md
@@ -1,5 +1,0 @@
-# Esper console
-
-The Esper console is a feature-rich user interface for you to operate and manage your fleet of Android devices. Esper provides a range of super simple options to deploy company‑owned devices at scale.
-
-For more info [click here ](../console.md)

--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
     "eslint-plugin-vue": "6.2.2",
     "prettier": "2.0.5",
     "vuepress": "1.5.2",
-    "vuepress-plugin-google-tag-manager": "0.0.4"
+    "vuepress-plugin-google-tag-manager": "0.0.4",
+    "vuepress-plugin-robots": "^1.0.1",
+    "vuepress-plugin-sitemap": "^2.3.1"
   },
   "devDependencies": {
     "@vuepress/plugin-back-to-top": "1.5.2",


### PR DESCRIPTION
Following issues has been fixed

1. Duplicate content issues - Both the pages point to the same content. https://docs.esper.io/home/console/ & https://docs.esper.io/home/console.html

2. Add a Sitemap for docs pages 

3. Add robot.txt file.

