### PR TITLE
Dev97

### DIFF
--- a/docs/home/release-notes/general/README.md
+++ b/docs/home/release-notes/general/README.md
@@ -2,7 +2,7 @@
 
 List of all the Console release notes:
 
-- [DevRel 97 (November 2022)(./devrel-97.md)
+- [DevRel 97 (November 2022](./devrel-97.md)
 - [DevRel 95 (October 2022)](./devrel-95.md)
 - [DevRel 93 (September 2022)](./devrel-93.md)
 - [DevRel 91 (August 2022)](./devrel-91.md)

--- a/docs/home/release-notes/general/README.md
+++ b/docs/home/release-notes/general/README.md
@@ -2,7 +2,7 @@
 
 List of all the Console release notes:
 
-- [DevRel 97 (November 2022](./devrel-97.md)
+- [DevRel 97 (November 2022)](./devrel-97.md)
 - [DevRel 95 (October 2022)](./devrel-95.md)
 - [DevRel 93 (September 2022)](./devrel-93.md)
 - [DevRel 91 (August 2022)](./devrel-91.md)

--- a/docs/home/release-notes/general/devrel-97.md
+++ b/docs/home/release-notes/general/devrel-97.md
@@ -18,6 +18,8 @@ We’ve added some new features in this release to make the most out of provisio
 
 - We’ve added the unique capability for Esper Foundation for Android x86 to support 802.1X via Ethernet. As part of this support you can now configure the required Ethernet certificate via JSON Settings in a Template or Blueprint, or via Namespace API.
 
+- We’ve added the ability to set static IP addresses to a network via Wi-Fi and Ethernet for Esper Foundation for Android on x86 devices running on SDK 3.0+.
+
 If you’re using Esper’s Blueprints feature, you now have the option to prevent enrolling devices in Android EMM (AKA Managed Google Play) during provisioning. Use this option if you do not need Play Store Apps for your deployment. If you choose this and later on wish to add Android EMM capabilities to your devices, they will need to be factory reset and re-provisioned.
 
  


### PR DESCRIPTION
Add - We’ve added the ability to set static IP addresses to a network via Wi-Fi and Ethernet for Esper Foundation for Android on x86 devices running on SDK 3.0+ to devlrel new features section. 